### PR TITLE
ECOM-14 ECOM | Issues | Create Product without Category name results in API failure

### DIFF
--- a/ms-product/src/main/resources/application.properties
+++ b/ms-product/src/main/resources/application.properties
@@ -1,5 +1,5 @@
-logging.level.org.springframework.web=TRACE
-logging.level.org.hibernate.orm.jdbc.bind=TRACE
+logging.level.org.springframework.web=INFO
+#logging.level.org.hibernate.orm.jdbc.bind=TRACE
 
 server.port=8100
 spring.application.name=ms-product


### PR DESCRIPTION
- Add MapStruct configuration to set category based on conditions.
- Add changes to properties for debugging purpose.
